### PR TITLE
feat(api): Go API foundation — DB pool, HTTP server, JWT auth, tenant middleware

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,16 @@
-POSTGRES_PASSWORD=
+# PostgreSQL superuser password (used by billing role + migration runner)
+POSTGRES_PASSWORD=changeme
+
+# Password for billing_app role (non-superuser, enforces RLS)
+# Set by migration runner via POSTGRES_APP_PASSWORD env var
+POSTGRES_APP_PASSWORD=changeme_app
+
+# Optional overrides (defaults shown)
+# POSTGRES_DB=billing_dev
+# POSTGRES_USER=billing
+# PORT=8080
+# GO_ENV=development
+
+# Stripe (required for webhook + payment processing)
+STRIPE_SECRET_KEY=sk_test_...
+STRIPE_WEBHOOK_SECRET=whsec_...

--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,9 @@ POSTGRES_APP_PASSWORD=changeme_app
 # PORT=8080
 # GO_ENV=development
 
+# JWT signing secret (min. 32 bytes, random)
+JWT_SECRET=change-me-to-a-random-secret-at-least-32-chars
+
 # Stripe (required for webhook + payment processing)
 STRIPE_SECRET_KEY=sk_test_...
 STRIPE_WEBHOOK_SECRET=whsec_...

--- a/api/cmd/migrate/main.go
+++ b/api/cmd/migrate/main.go
@@ -1,0 +1,151 @@
+// migrate runs all SQL migration files from the migrations/ directory in
+// alphabetical order, each in its own transaction. Already-applied migrations
+// are tracked in schema_migrations and skipped on re-runs. After all migrations
+// succeed, it sets the billing_app role password from POSTGRES_APP_PASSWORD.
+//
+// Uses DATABASE_URL (superuser billing) — NOT DATABASE_APP_URL.
+// Run: go run ./cmd/migrate
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+
+	_ "github.com/lib/pq"
+)
+
+func main() {
+	if err := run(); err != nil {
+		slog.Error("migration failed", "error", err)
+		os.Exit(1)
+	}
+	slog.Info("migrations completed successfully")
+}
+
+func run() error {
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		return fmt.Errorf("DATABASE_URL not set")
+	}
+
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		return fmt.Errorf("open db: %w", err)
+	}
+	defer db.Close()
+
+	if err := db.Ping(); err != nil {
+		return fmt.Errorf("ping db: %w", err)
+	}
+
+	if err := ensureMigrationsTable(db); err != nil {
+		return fmt.Errorf("ensure migrations table: %w", err)
+	}
+
+	// Find migration files
+	migrationsDir := "migrations"
+	entries, err := os.ReadDir(migrationsDir)
+	if err != nil {
+		return fmt.Errorf("read migrations dir: %w", err)
+	}
+
+	var files []string
+	for _, e := range entries {
+		if !e.IsDir() && filepath.Ext(e.Name()) == ".sql" {
+			files = append(files, filepath.Join(migrationsDir, e.Name()))
+		}
+	}
+	sort.Strings(files)
+
+	if len(files) == 0 {
+		slog.Info("no migration files found")
+		return nil
+	}
+
+	// Run each migration in its own transaction (skip already-applied ones)
+	for _, file := range files {
+		filename := filepath.Base(file)
+
+		applied, err := isMigrationApplied(db, filename)
+		if err != nil {
+			return fmt.Errorf("check migration %s: %w", filename, err)
+		}
+		if applied {
+			slog.Info("migration already applied, skipping", "file", filename)
+			continue
+		}
+
+		if err := runMigration(db, file, filename); err != nil {
+			return fmt.Errorf("migration %s: %w", filename, err)
+		}
+	}
+
+	// Set billing_app password after all migrations succeed
+	if appPassword := os.Getenv("POSTGRES_APP_PASSWORD"); appPassword != "" {
+		// ALTER ROLE does not support $1 placeholders — safe here since value
+		// comes from env var, not user input.
+		if _, err := db.Exec(fmt.Sprintf("ALTER ROLE billing_app PASSWORD '%s'", appPassword)); err != nil {
+			return fmt.Errorf("set billing_app password: %w", err)
+		}
+		slog.Info("billing_app password set")
+	} else {
+		slog.Warn("POSTGRES_APP_PASSWORD not set — billing_app has no password")
+	}
+
+	return nil
+}
+
+// ensureMigrationsTable creates the schema_migrations tracking table if it
+// does not already exist. Uses the superuser connection, so it runs before RLS.
+func ensureMigrationsTable(db *sql.DB) error {
+	_, err := db.Exec(`CREATE TABLE IF NOT EXISTS schema_migrations (
+		filename   TEXT PRIMARY KEY,
+		applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+	)`)
+	return err
+}
+
+func isMigrationApplied(db *sql.DB, filename string) (bool, error) {
+	var count int
+	err := db.QueryRow(
+		"SELECT COUNT(*) FROM schema_migrations WHERE filename = $1",
+		filename,
+	).Scan(&count)
+	return count > 0, err
+}
+
+func runMigration(db *sql.DB, file, filename string) error {
+	content, err := os.ReadFile(file)
+	if err != nil {
+		return fmt.Errorf("read file: %w", err)
+	}
+
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+
+	if _, err := tx.Exec(string(content)); err != nil {
+		tx.Rollback() //nolint:errcheck
+		return fmt.Errorf("exec: %w", err)
+	}
+
+	if _, err := tx.Exec(
+		"INSERT INTO schema_migrations(filename) VALUES ($1)",
+		filename,
+	); err != nil {
+		tx.Rollback() //nolint:errcheck
+		return fmt.Errorf("mark applied: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+
+	slog.Info("migration applied", "file", filename)
+	return nil
+}

--- a/api/cmd/server/main.go
+++ b/api/cmd/server/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	"os"
@@ -14,6 +15,7 @@ import (
 
 	"billing-platform/api/internal/db"
 	"billing-platform/api/internal/handler"
+	apimiddleware "billing-platform/api/internal/middleware"
 )
 
 func main() {
@@ -41,6 +43,7 @@ func main() {
 	r.Use(middleware.RealIP)
 	r.Use(middleware.Recoverer)
 	r.Use(middleware.CleanPath)
+	r.Use(apimiddleware.NewRequestLogger())
 
 	r.Get("/health", handler.NewHealth(pool))
 
@@ -60,7 +63,7 @@ func main() {
 	// Start server in background
 	go func() {
 		slog.Info("server starting", "addr", srv.Addr)
-		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			slog.Error("server error", "error", err)
 			os.Exit(1)
 		}

--- a/api/cmd/server/main.go
+++ b/api/cmd/server/main.go
@@ -29,6 +29,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	jwtSecret := os.Getenv("JWT_SECRET")
+	if len(jwtSecret) < 32 {
+		slog.Error("JWT_SECRET must be at least 32 bytes")
+		os.Exit(1)
+	}
+
 	pool, err := db.New(context.Background(), appDSN)
 	if err != nil {
 		// Do not log err directly — may contain DSN with credentials
@@ -45,7 +51,15 @@ func main() {
 	r.Use(middleware.CleanPath)
 	r.Use(apimiddleware.NewRequestLogger())
 
+	// Public routes (no auth)
 	r.Get("/health", handler.NewHealth(pool))
+
+	// Protected routes — all behind JWT + tenant middleware
+	r.Group(func(r chi.Router) {
+		r.Use(apimiddleware.NewAuth([]byte(jwtSecret)))
+		r.Use(apimiddleware.NewTenant(pool))
+		// future handlers go here
+	})
 
 	port := os.Getenv("PORT")
 	if port == "" {

--- a/api/cmd/server/main.go
+++ b/api/cmd/server/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 
+	"billing-platform/api/internal/db"
 	"billing-platform/api/internal/handler"
 )
 
@@ -19,16 +20,37 @@ func main() {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 	slog.SetDefault(logger)
 
+	// Connect as billing_app (non-superuser) — required for RLS to take effect
+	appDSN := os.Getenv("DATABASE_APP_URL")
+	if appDSN == "" {
+		slog.Error("DATABASE_APP_URL not set")
+		os.Exit(1)
+	}
+
+	pool, err := db.New(context.Background(), appDSN)
+	if err != nil {
+		// Do not log err directly — may contain DSN with credentials
+		slog.Error("failed to connect to database — check DATABASE_APP_URL")
+		os.Exit(1)
+	}
+	defer pool.Close()
+	slog.Info("database connected", "role", "billing_app")
+
 	r := chi.NewRouter()
 	r.Use(middleware.RequestID)
 	r.Use(middleware.RealIP)
 	r.Use(middleware.Recoverer)
 	r.Use(middleware.CleanPath)
 
-	r.Get("/health", handler.Health)
+	r.Get("/health", handler.NewHealth(pool))
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
 
 	srv := &http.Server{
-		Addr:         ":8080",
+		Addr:         ":" + port,
 		Handler:      r,
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 30 * time.Second,

--- a/api/go.mod
+++ b/api/go.mod
@@ -5,6 +5,8 @@ go 1.26.1
 require github.com/go-chi/chi/v5 v5.2.5
 
 require (
+	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/jmoiron/sqlx v1.4.0 // indirect
 	github.com/lib/pq v1.12.3 // indirect
 )

--- a/api/go.mod
+++ b/api/go.mod
@@ -3,3 +3,8 @@ module billing-platform/api
 go 1.26.1
 
 require github.com/go-chi/chi/v5 v5.2.5
+
+require (
+	github.com/jmoiron/sqlx v1.4.0 // indirect
+	github.com/lib/pq v1.12.3 // indirect
+)

--- a/api/go.sum
+++ b/api/go.sum
@@ -2,6 +2,10 @@ filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4
 github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
 github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
 github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jmoiron/sqlx v1.4.0 h1:1PLqN7S1UYp5t4SrVVnt4nUVNemrDAtxlulVe+Qgm3o=
 github.com/jmoiron/sqlx v1.4.0/go.mod h1:ZrZ7UsYB/weZdl2Bxg6jCRO9c3YHl8r3ahlKmRT4JLY=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=

--- a/api/go.sum
+++ b/api/go.sum
@@ -1,2 +1,10 @@
+filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
 github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
+github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
+github.com/jmoiron/sqlx v1.4.0 h1:1PLqN7S1UYp5t4SrVVnt4nUVNemrDAtxlulVe+Qgm3o=
+github.com/jmoiron/sqlx v1.4.0/go.mod h1:ZrZ7UsYB/weZdl2Bxg6jCRO9c3YHl8r3ahlKmRT4JLY=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/lib/pq v1.12.3 h1:tTWxr2YLKwIvK90ZXEw8GP7UFHtcbTtty8zsI+YjrfQ=
+github.com/lib/pq v1.12.3/go.mod h1:/p+8NSbOcwzAEI7wiMXFlgydTwcgTr3OSKMsD2BitpA=
+github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=

--- a/api/internal/db/db.go
+++ b/api/internal/db/db.go
@@ -1,0 +1,45 @@
+// Package db provides the sqlx connection pool for the billing_app role.
+// The billing_app role is a non-superuser subject to RLS — all application
+// queries must use this pool, never the superuser billing connection.
+package db
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	_ "github.com/lib/pq" // postgres driver
+)
+
+const (
+	maxOpenConns    = 25
+	maxIdleConns    = 5
+	connMaxLifetime = 5 * time.Minute
+	connMaxIdleTime = 1 * time.Minute
+	pingTimeout     = 5 * time.Second
+)
+
+// New opens a sqlx connection pool using the provided Postgres DSN and verifies
+// connectivity with a ping. The caller is responsible for calling db.Close().
+func New(ctx context.Context, dsn string) (*sqlx.DB, error) {
+	db, err := sqlx.Open("postgres", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open db: %w", err)
+	}
+
+	db.SetMaxOpenConns(maxOpenConns)
+	db.SetMaxIdleConns(maxIdleConns)
+	db.SetConnMaxLifetime(connMaxLifetime)
+	db.SetConnMaxIdleTime(connMaxIdleTime)
+
+	pingCtx, cancel := context.WithTimeout(ctx, pingTimeout)
+	defer cancel()
+
+	if err := db.PingContext(pingCtx); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("ping db: %w", err)
+	}
+
+	return db, nil
+}

--- a/api/internal/handler/health.go
+++ b/api/internal/handler/health.go
@@ -1,8 +1,12 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
+	"time"
+
+	"github.com/jmoiron/sqlx"
 )
 
 // HealthResponse is the response body for the health check endpoint.
@@ -10,9 +14,23 @@ type HealthResponse struct {
 	Status string `json:"status"`
 }
 
-// Health handles GET /health and returns a simple liveness response.
-func Health(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(HealthResponse{Status: "ok"}) //nolint:errcheck
+// NewHealth returns an http.HandlerFunc for GET /health.
+// It pings the database and returns "ok" (200) or "degraded" (503).
+func NewHealth(db *sqlx.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
+		defer cancel()
+
+		status := "ok"
+		code := http.StatusOK
+
+		if err := db.PingContext(ctx); err != nil {
+			status = "degraded"
+			code = http.StatusServiceUnavailable
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(code)
+		json.NewEncoder(w).Encode(HealthResponse{Status: status}) //nolint:errcheck
+	}
 }

--- a/api/internal/handler/health_test.go
+++ b/api/internal/handler/health_test.go
@@ -1,42 +1,102 @@
 package handler_test
 
 import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/jmoiron/sqlx"
+
 	"billing-platform/api/internal/handler"
 )
 
-func TestHealth_ReturnsOK(t *testing.T) {
+// mockDriver + mockConn implement driver.Driver, driver.Conn, and driver.Pinger
+// to create a fake sqlx.DB without real Postgres. pingErr controls PingContext.
+type mockDriver struct{ pingErr error }
+type mockConn struct{ pingErr error }
+
+func (d *mockDriver) Open(_ string) (driver.Conn, error)  { return &mockConn{pingErr: d.pingErr}, nil }
+func (c *mockConn) Prepare(_ string) (driver.Stmt, error) { return nil, nil }
+func (c *mockConn) Close() error                          { return nil }
+func (c *mockConn) Begin() (driver.Tx, error)             { return nil, nil }
+
+// Ping implements driver.Pinger so db.PingContext uses our error.
+func (c *mockConn) Ping(_ context.Context) error { return c.pingErr }
+
+func newMockDB(t *testing.T, pingErr error) *sqlx.DB {
+	t.Helper()
+	driverName := "mock_" + t.Name()
+	sql.Register(driverName, &mockDriver{pingErr: pingErr})
+	db, err := sqlx.Open(driverName, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+
+func TestHealth_DBUp_ReturnsOK(t *testing.T) {
+	db := newMockDB(t, nil)
+	defer db.Close()
+
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	w := httptest.NewRecorder()
 
-	handler.Health(w, req)
+	handler.NewHealth(db)(w, req)
 
 	res := w.Result()
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
-		t.Errorf("expected status 200, got %d", res.StatusCode)
+		t.Errorf("expected 200, got %d", res.StatusCode)
 	}
 
 	var body map[string]string
 	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
-		t.Fatalf("failed to decode response body: %v", err)
+		t.Fatalf("decode: %v", err)
 	}
-
 	if body["status"] != "ok" {
 		t.Errorf("expected status=ok, got %q", body["status"])
 	}
 }
 
-func TestHealth_ReturnsJSONContentType(t *testing.T) {
+func TestHealth_DBDown_ReturnsDegraded(t *testing.T) {
+	db := newMockDB(t, errors.New("connection refused"))
+	defer db.Close()
+
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	w := httptest.NewRecorder()
 
-	handler.Health(w, req)
+	handler.NewHealth(db)(w, req)
+
+	res := w.Result()
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("expected 503, got %d", res.StatusCode)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["status"] != "degraded" {
+		t.Errorf("expected status=degraded, got %q", body["status"])
+	}
+}
+
+func TestHealth_ReturnsJSONContentType(t *testing.T) {
+	db := newMockDB(t, nil)
+	defer db.Close()
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+
+	handler.NewHealth(db)(w, req)
 
 	ct := w.Result().Header.Get("Content-Type")
 	if ct != "application/json" {

--- a/api/internal/middleware/auth.go
+++ b/api/internal/middleware/auth.go
@@ -1,0 +1,71 @@
+package middleware
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+)
+
+type contextKey string
+
+const tenantIDKey contextKey = "tenant_id"
+
+// BillingClaims are the JWT claims we expect in every token.
+type BillingClaims struct {
+	TenantID string `json:"tenant_id"`
+	jwt.RegisteredClaims
+}
+
+// NewAuth returns a middleware that validates a Bearer JWT and puts the
+// tenant_id into the request context. Returns 401 on any failure.
+func NewAuth(jwtSecret []byte) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			tokenStr, err := extractBearer(r)
+			if err != nil {
+				http.Error(w, "Unauthorized", http.StatusUnauthorized)
+				return
+			}
+
+			claims := &BillingClaims{}
+			token, err := jwt.ParseWithClaims(tokenStr, claims, func(t *jwt.Token) (any, error) {
+				// Prevent alg:none and RSA confusion attacks
+				if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+					return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+				}
+				return jwtSecret, nil
+			})
+			if err != nil || !token.Valid {
+				http.Error(w, "Unauthorized", http.StatusUnauthorized)
+				return
+			}
+
+			tenantID, err := uuid.Parse(claims.TenantID)
+			if err != nil {
+				http.Error(w, "Unauthorized", http.StatusUnauthorized)
+				return
+			}
+
+			ctx := r.Context()
+			ctx = withTenantID(ctx, tenantID)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// extractBearer extracts the token string from "Authorization: Bearer <token>".
+func extractBearer(r *http.Request) (string, error) {
+	header := r.Header.Get("Authorization")
+	if header == "" {
+		return "", errors.New("missing Authorization header")
+	}
+	parts := strings.SplitN(header, " ", 2)
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
+		return "", errors.New("invalid Authorization header format")
+	}
+	return strings.TrimSpace(parts[1]), nil
+}

--- a/api/internal/middleware/auth_test.go
+++ b/api/internal/middleware/auth_test.go
@@ -1,0 +1,166 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+
+	"billing-platform/api/internal/middleware"
+)
+
+var testSecret = []byte("test-secret-32-bytes-long-enough!")
+
+func makeToken(t *testing.T, tenantID string, secret []byte, expiry time.Time) string {
+	t.Helper()
+	claims := jwt.MapClaims{
+		"tenant_id": tenantID,
+		"exp":       jwt.NewNumericDate(expiry),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	str, err := token.SignedString(secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return str
+}
+
+func okHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func TestAuth_ValidJWT_Passes(t *testing.T) {
+	tenantID := uuid.New().String()
+	token := makeToken(t, tenantID, testSecret, time.Now().Add(time.Hour))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+
+	middleware.NewAuth(testSecret)(okHandler()).ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestAuth_NoHeader_Returns401(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+
+	middleware.NewAuth(testSecret)(okHandler()).ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestAuth_InvalidToken_Returns401(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer not.a.valid.token")
+	w := httptest.NewRecorder()
+
+	middleware.NewAuth(testSecret)(okHandler()).ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestAuth_ExpiredToken_Returns401(t *testing.T) {
+	tenantID := uuid.New().String()
+	token := makeToken(t, tenantID, testSecret, time.Now().Add(-time.Hour))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+
+	middleware.NewAuth(testSecret)(okHandler()).ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestAuth_WrongSecret_Returns401(t *testing.T) {
+	tenantID := uuid.New().String()
+	token := makeToken(t, tenantID, []byte("other-secret"), time.Now().Add(time.Hour))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+
+	middleware.NewAuth(testSecret)(okHandler()).ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestAuth_InvalidTenantIDClaim_Returns401(t *testing.T) {
+	// tenant_id is not a valid UUID
+	token := makeToken(t, "not-a-uuid", testSecret, time.Now().Add(time.Hour))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+
+	middleware.NewAuth(testSecret)(okHandler()).ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestAuth_AlgNone_Returns401(t *testing.T) {
+	// Construct a token manually with alg:none to test the algorithm check
+	tenantID := uuid.New().String()
+	claims := jwt.MapClaims{
+		"tenant_id": tenantID,
+		"exp":       jwt.NewNumericDate(time.Now().Add(time.Hour)),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodNone, claims)
+	tokenStr, err := token.SignedString(jwt.UnsafeAllowNoneSignatureType)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+tokenStr)
+	w := httptest.NewRecorder()
+
+	middleware.NewAuth(testSecret)(okHandler()).ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 for alg:none, got %d", w.Code)
+	}
+}
+
+func TestAuth_TenantIDInContext(t *testing.T) {
+	tenantID := uuid.New()
+	token := makeToken(t, tenantID.String(), testSecret, time.Now().Add(time.Hour))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+
+	var gotID uuid.UUID
+	capture := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		id, err := middleware.TenantIDFromContext(r.Context())
+		if err != nil {
+			t.Errorf("TenantIDFromContext: %v", err)
+		}
+		gotID = id
+	})
+
+	middleware.NewAuth(testSecret)(capture).ServeHTTP(w, req)
+
+	if gotID != tenantID {
+		t.Errorf("context tenant_id: want %s, got %s", tenantID, gotID)
+	}
+}

--- a/api/internal/middleware/logging.go
+++ b/api/internal/middleware/logging.go
@@ -1,0 +1,30 @@
+package middleware
+
+import (
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5/middleware"
+)
+
+// NewRequestLogger returns a middleware that logs each request with slog.
+// Logged fields: method, path, status, latency_ms, request_id.
+func NewRequestLogger() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			start := time.Now()
+			ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
+
+			next.ServeHTTP(ww, r)
+
+			slog.InfoContext(r.Context(), "request",
+				"method", r.Method,
+				"path", r.URL.Path,
+				"status", ww.Status(),
+				"latency_ms", time.Since(start).Milliseconds(),
+				"request_id", middleware.GetReqID(r.Context()),
+			)
+		})
+	}
+}

--- a/api/internal/middleware/logging_test.go
+++ b/api/internal/middleware/logging_test.go
@@ -1,0 +1,94 @@
+package middleware_test
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	chimiddleware "github.com/go-chi/chi/v5/middleware"
+
+	"billing-platform/api/internal/middleware"
+)
+
+// capturingHandler is a slog.Handler that records the last logged record.
+type capturingHandler struct {
+	last  *slog.Record
+	attrs []slog.Attr
+}
+
+func (h *capturingHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+func (h *capturingHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &capturingHandler{attrs: append(h.attrs, attrs...)}
+}
+func (h *capturingHandler) WithGroup(_ string) slog.Handler { return h }
+func (h *capturingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.last = &r
+	return nil
+}
+
+func attrValue(r *slog.Record, key string) any {
+	var val any
+	r.Attrs(func(a slog.Attr) bool {
+		if a.Key == key {
+			val = a.Value.Any()
+			return false
+		}
+		return true
+	})
+	return val
+}
+
+func TestRequestLogger_LogsMethodPathStatus(t *testing.T) {
+	handler := &capturingHandler{}
+	slog.SetDefault(slog.New(handler))
+	t.Cleanup(func() { slog.SetDefault(slog.Default()) })
+
+	// Wrap a simple 201 handler with RequestID + our logger
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	})
+	chain := chimiddleware.RequestID(middleware.NewRequestLogger()(inner))
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	chain.ServeHTTP(w, req)
+
+	if handler.last == nil {
+		t.Fatal("expected a log record, got none")
+	}
+
+	r := handler.last
+	if got := attrValue(r, "method"); got != "GET" {
+		t.Errorf("method: want GET, got %v", got)
+	}
+	if got := attrValue(r, "path"); got != "/health" {
+		t.Errorf("path: want /health, got %v", got)
+	}
+	if got, ok := attrValue(r, "status").(int64); !ok || got != http.StatusCreated {
+		t.Errorf("status: want 201, got %v", attrValue(r, "status"))
+	}
+	if attrValue(r, "latency_ms") == nil {
+		t.Error("latency_ms missing")
+	}
+}
+
+func TestRequestLogger_DefaultStatus200(t *testing.T) {
+	handler := &capturingHandler{}
+	slog.SetDefault(slog.New(handler))
+	t.Cleanup(func() { slog.SetDefault(slog.Default()) })
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// no explicit WriteHeader → defaults to 200
+		w.Write([]byte("ok")) //nolint:errcheck
+	})
+	middleware.NewRequestLogger()(inner).ServeHTTP(
+		httptest.NewRecorder(),
+		httptest.NewRequest(http.MethodGet, "/", nil),
+	)
+
+	if got, ok := attrValue(handler.last, "status").(int64); !ok || got != http.StatusOK {
+		t.Errorf("status: want 200, got %v", attrValue(handler.last, "status"))
+	}
+}

--- a/api/internal/middleware/tenant.go
+++ b/api/internal/middleware/tenant.go
@@ -1,0 +1,78 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+)
+
+// ErrNoTenantInContext is returned when no tenant_id is found in the context.
+var ErrNoTenantInContext = errors.New("no tenant_id in context")
+
+type dbConnContextKey struct{}
+
+// withTenantID stores the tenant UUID in ctx.
+func withTenantID(ctx context.Context, id uuid.UUID) context.Context {
+	return context.WithValue(ctx, tenantIDKey, id)
+}
+
+// TenantIDFromContext retrieves the tenant UUID set by the auth middleware.
+// Returns ErrNoTenantInContext if the value is absent.
+func TenantIDFromContext(ctx context.Context) (uuid.UUID, error) {
+	id, ok := ctx.Value(tenantIDKey).(uuid.UUID)
+	if !ok {
+		return uuid.Nil, ErrNoTenantInContext
+	}
+	return id, nil
+}
+
+// DBConnFromContext retrieves the per-request pinned connection set by
+// NewTenant. Repositories must use this connection to ensure RLS applies.
+func DBConnFromContext(ctx context.Context) (*sqlx.Conn, bool) {
+	conn, ok := ctx.Value(dbConnContextKey{}).(*sqlx.Conn)
+	return conn, ok
+}
+
+// NewTenant returns a middleware that:
+//  1. Reads tenant_id from context (set by NewAuth).
+//  2. Acquires a dedicated connection from the pool (pinned for this request).
+//  3. Executes SET LOCAL app.current_tenant_id within a transaction so RLS
+//     reads the correct value on the exact same connection.
+//  4. Stores the pinned connection in the context for repositories to use.
+//
+// Repositories must call DBConnFromContext to retrieve this connection —
+// using the pool directly would bypass the tenant variable.
+func NewTenant(db *sqlx.DB) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			tenantID, err := TenantIDFromContext(r.Context())
+			if err != nil {
+				http.Error(w, "Unauthorized", http.StatusUnauthorized)
+				return
+			}
+
+			// Acquire a dedicated connection — pinned for the lifetime of this request
+			conn, err := db.Connx(r.Context())
+			if err != nil {
+				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+				return
+			}
+			defer conn.Close() //nolint:errcheck
+
+			// SET (not SET LOCAL) so the variable persists beyond a single statement
+			// on this specific connection. Handlers share this connection via context.
+			if _, err := conn.ExecContext(r.Context(),
+				"SET app.current_tenant_id = $1", tenantID.String(),
+			); err != nil {
+				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+				return
+			}
+
+			ctx := context.WithValue(r.Context(), dbConnContextKey{}, conn)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}

--- a/api/internal/middleware/tenant_test.go
+++ b/api/internal/middleware/tenant_test.go
@@ -1,0 +1,78 @@
+package middleware_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+
+	"billing-platform/api/internal/middleware"
+)
+
+func TestTenantIDFromContext_Missing_ReturnsError(t *testing.T) {
+	_, err := middleware.TenantIDFromContext(context.Background())
+	if err == nil {
+		t.Error("expected error for missing tenant_id, got nil")
+	}
+	if !errors.Is(err, middleware.ErrNoTenantInContext) {
+		t.Errorf("expected ErrNoTenantInContext, got %v", err)
+	}
+}
+
+func TestNewTenant_NoTenantInContext_Returns401(t *testing.T) {
+	// NewTenant with nil db — returns 401 before touching db when tenant is missing
+	handler := middleware.NewTenant(nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	// No tenant_id in context
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestNewTenant_WithTenantInContext_PassesThrough(t *testing.T) {
+	// Verify that auth middleware → tenant middleware chain sets tenant in context
+	// and the handler receives it correctly (integration-style, no real DB needed
+	// since tenant middleware is exercised via auth middleware path)
+	tenantID := uuid.New()
+	claims := jwt.MapClaims{
+		"tenant_id": tenantID.String(),
+		"exp":       jwt.NewNumericDate(time.Now().Add(time.Hour)),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenStr, err := token.SignedString(testSecret)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var gotID uuid.UUID
+	capture := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		id, err := middleware.TenantIDFromContext(r.Context())
+		if err != nil {
+			t.Errorf("TenantIDFromContext: %v", err)
+		}
+		gotID = id
+	})
+
+	// Only test auth middleware here (tenant middleware needs DB)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+tokenStr)
+	w := httptest.NewRecorder()
+
+	middleware.NewAuth(testSecret)(capture).ServeHTTP(w, req)
+
+	if gotID != tenantID {
+		t.Errorf("tenant_id in context: want %s, got %s", tenantID, gotID)
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - go_mod_cache:/go/pkg/mod
     environment:
       DATABASE_APP_URL: postgresql://billing_app:${POSTGRES_APP_PASSWORD}@db:5432/${POSTGRES_DB:-billing_dev}?sslmode=disable
+      JWT_SECRET: ${JWT_SECRET}
       STRIPE_SECRET_KEY: ${STRIPE_SECRET_KEY}
       STRIPE_WEBHOOK_SECRET: ${STRIPE_WEBHOOK_SECRET}
       GO_ENV: ${GO_ENV:-development}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - ./api:/app
       - go_mod_cache:/go/pkg/mod
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER:-billing}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-billing_dev}
+      DATABASE_APP_URL: postgresql://billing_app:${POSTGRES_APP_PASSWORD}@db:5432/${POSTGRES_DB:-billing_dev}?sslmode=disable
       STRIPE_SECRET_KEY: ${STRIPE_SECRET_KEY}
       STRIPE_WEBHOOK_SECRET: ${STRIPE_WEBHOOK_SECRET}
       GO_ENV: ${GO_ENV:-development}
@@ -54,7 +54,7 @@ services:
     volumes:
       - ./reporting:/app
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER:-billing}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-billing_dev}
+      DATABASE_URL: postgresql://${POSTGRES_USER:-billing}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-billing_dev}?sslmode=disable
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Feature

HTTP-Server-Grundstruktur für die Go API. Einziger Service der direkt mit der Datenbank spricht. Alle Requests werden einem Tenant zugeordnet; RLS erzwingt Datenisolation auf DB-Ebene.

## Enthaltene Tickets

- #16 DB connection pool (billing_app, non-superuser) + idempotenter Migration Runner
- #17 HTTP server — chi router, health endpoint, slog request logging, graceful shutdown
- #18 JWT auth middleware + tenant context middleware

## Änderungen

- `api/internal/db`: sqlx connection pool als `billing_app` (RLS wird erzwungen)
- `api/cmd/migrate`: Migration Runner mit `schema_migrations`-Tracking (idempotent)
- `api/cmd/server`: HTTP-Server, JWT_SECRET-Validierung (min. 32 bytes), graceful shutdown
- `api/internal/handler/health`: DB-Ping, ok/degraded response
- `api/internal/middleware/auth`: JWT-Validierung (HMAC-only, alg:none geblockt), 401 bei Fehler
- `api/internal/middleware/tenant`: Pinned db.Connx() pro Request, SET app.current_tenant_id, DBConnFromContext für Repositories
- `api/internal/middleware/logging`: slog request logger (method, path, status, latency_ms)
- `docker-compose.yml`: DATABASE_APP_URL, JWT_SECRET — superuser-DSN nicht im API-Container

## Getestet

- [x] Alle automatischen Checks grün (go test ./... -race, go vet)
- [x] Security-Checker konsultiert (beide Passes: CLEAN)
- [x] Manuelle Pre-PR Prüfliste abgehakt
- [x] docker compose up api → Server startet, /health antwortet mit 200
- [x] JWT_SECRET < 32 Bytes → Server startet nicht

closes #16, closes #17, closes #18