### PR TITLE
feat(billing): Rust billing-engine foundation — Money type, Currency, AppError

### DIFF
--- a/billing-engine/src/error.rs
+++ b/billing-engine/src/error.rs
@@ -2,16 +2,89 @@ use thiserror::Error;
 
 /// All errors that can occur in the billing engine.
 #[derive(Debug, Error, PartialEq)]
-pub enum BillingError {
+pub enum AppError {
+    /// A billing calculation attempted to divide by zero.
     #[error("division by zero in billing calculation")]
     DivisionByZero,
 
+    /// A monetary amount was invalid (e.g. NaN, infinite, or out of range).
+    #[error("invalid amount: {0}")]
+    InvalidAmount(String),
+
+    /// A monetary amount was negative where only non-negative values are valid.
+    /// Distinct from `InvalidAmount` so callers can match on this case programmatically.
+    #[error("amount must not be negative: {0}")]
+    NegativeAmount(String),
+
+    /// The billing period parameters are inconsistent.
     #[error("invalid period: days_remaining ({0}) exceeds days_in_period ({1})")]
     InvalidPeriod(u32, u32),
 
+    /// Two monetary values with different currencies were combined.
     #[error("currency mismatch: expected {expected}, got {got}")]
     CurrencyMismatch { expected: String, got: String },
 
-    #[error("amount overflow")]
+    /// A monetary amount overflowed the representable range.
+    #[error("amount overflow: value exceeds i64 range")]
     Overflow,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn division_by_zero_is_constructible() {
+        let e = AppError::DivisionByZero;
+        assert_eq!(e.to_string(), "division by zero in billing calculation");
+    }
+
+    #[test]
+    fn invalid_amount_carries_reason() {
+        let e = AppError::InvalidAmount("amount must be >= 0".to_string());
+        assert_eq!(e.to_string(), "invalid amount: amount must be >= 0");
+    }
+
+    #[test]
+    fn invalid_period_shows_both_values() {
+        let e = AppError::InvalidPeriod(15, 10);
+        assert_eq!(
+            e.to_string(),
+            "invalid period: days_remaining (15) exceeds days_in_period (10)"
+        );
+    }
+
+    #[test]
+    fn currency_mismatch_shows_both_currencies() {
+        let e = AppError::CurrencyMismatch {
+            expected: "EUR".to_string(),
+            got: "USD".to_string(),
+        };
+        assert_eq!(e.to_string(), "currency mismatch: expected EUR, got USD");
+    }
+
+    #[test]
+    fn overflow_is_constructible() {
+        let e = AppError::Overflow;
+        assert_eq!(e.to_string(), "amount overflow: value exceeds i64 range");
+    }
+
+    #[test]
+    fn negative_amount_carries_reason() {
+        let e = AppError::NegativeAmount("plan price must be >= 0".to_string());
+        assert_eq!(
+            e.to_string(),
+            "amount must not be negative: plan price must be >= 0"
+        );
+    }
+
+    #[test]
+    fn errors_are_comparable() {
+        assert_eq!(AppError::DivisionByZero, AppError::DivisionByZero);
+        assert_ne!(AppError::DivisionByZero, AppError::Overflow);
+        assert_ne!(
+            AppError::InvalidAmount("x".to_string()),
+            AppError::NegativeAmount("x".to_string())
+        );
+    }
 }

--- a/billing-engine/src/lib.rs
+++ b/billing-engine/src/lib.rs
@@ -2,6 +2,6 @@ pub mod error;
 pub mod money;
 pub mod plans;
 
-pub use error::BillingError;
+pub use error::AppError;
 pub use money::{Currency, Money};
 pub use plans::{BillingInterval, Plan};

--- a/billing-engine/src/money.rs
+++ b/billing-engine/src/money.rs
@@ -1,5 +1,8 @@
+use rust_decimal::prelude::{RoundingStrategy, ToPrimitive};
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
+
+use crate::error::BillingError;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Currency {
@@ -41,12 +44,20 @@ impl Money {
     }
 
     /// Returns the amount as integer cents (e.g. 9.99 → 999).
-    pub fn to_cents(&self) -> i64 {
+    ///
+    /// Uses `ROUND_HALF_UP` (e.g. 0.5 → 1, 1.5 → 2) — the standard for
+    /// financial calculations in most jurisdictions.
+    ///
+    /// # Errors
+    /// Returns `BillingError::Overflow` if the amount exceeds `i64` range
+    /// (approximately ±92 trillion cents / ±920 billion USD). This should
+    /// never occur with amounts created via `from_cents`, but can occur if
+    /// `Money::new` is called with an extreme `Decimal` value.
+    pub fn to_cents(&self) -> Result<i64, BillingError> {
         (self.amount * dec!(100))
-            .round_dp(0)
-            .to_string()
-            .parse::<i64>()
-            .unwrap_or(0)
+            .round_dp_with_strategy(0, RoundingStrategy::MidpointAwayFromZero)
+            .to_i64()
+            .ok_or(BillingError::Overflow)
     }
 }
 
@@ -85,26 +96,72 @@ mod tests {
     fn to_cents_roundtrip() {
         let cents = 2900i64;
         let m = Money::from_cents(cents, Currency::EUR);
-        assert_eq!(m.to_cents(), cents);
+        assert_eq!(m.to_cents().unwrap(), cents);
     }
 
     #[test]
     fn to_cents_negative_roundtrip() {
         let cents = -500i64;
         let m = Money::from_cents(cents, Currency::EUR);
-        assert_eq!(m.to_cents(), cents);
+        assert_eq!(m.to_cents().unwrap(), cents);
     }
 
     #[test]
-    fn to_cents_rounds_correctly() {
-        // 9.995 should round to 1000 cents
+    fn to_cents_rounds_half_up() {
+        // 9.995 → 999.5 cents → rounds to 1000 (ROUND_HALF_UP)
         let m = Money::new(dec!(9.995), Currency::EUR);
-        assert_eq!(m.to_cents(), 1000);
+        assert_eq!(m.to_cents().unwrap(), 1000);
+    }
+
+    #[test]
+    fn to_cents_rounds_half_up_even_base() {
+        // 10.005 → 1000.5 cents → rounds to 1001 (ROUND_HALF_UP, not Banker's)
+        let m = Money::new(dec!(10.005), Currency::EUR);
+        assert_eq!(m.to_cents().unwrap(), 1001);
+    }
+
+    #[test]
+    fn to_cents_overflow_returns_error() {
+        // Amount far exceeds i64 range → must return Err, not silent 0
+        let huge = Decimal::from(i64::MAX) + Decimal::ONE;
+        let m = Money::new(huge, Currency::EUR);
+        assert!(m.to_cents().is_err());
     }
 
     #[test]
     fn display_formats_correctly() {
         let m = Money::from_cents(999, Currency::EUR);
         assert_eq!(m.to_string(), "9.99 EUR");
+    }
+
+    // Property-based tests — invariants that must hold for all inputs
+    mod proptest_suite {
+        use super::*;
+        use proptest::prelude::*;
+
+        proptest! {
+            /// `from_cents(x).to_cents() == x` for all practical financial amounts.
+            /// Range bounded to ±i64::MAX/100 to avoid overflow when multiplying by 100
+            /// inside `to_cents`. Covers ±92 trillion cents (≈ ±920 billion USD).
+            #[test]
+            fn from_cents_to_cents_roundtrip(cents in i64::MIN/100..=i64::MAX/100) {
+                let m = Money::from_cents(cents, Currency::EUR);
+                prop_assert_eq!(m.to_cents().unwrap(), cents);
+            }
+
+            /// Currency is preserved through from_cents (no mutation).
+            #[test]
+            fn currency_preserved(cents in -1_000_000_00i64..=1_000_000_00i64) {
+                let m = Money::from_cents(cents, Currency::USD);
+                prop_assert_eq!(m.currency, Currency::USD);
+            }
+
+            /// Amount is never negative for non-negative cent inputs.
+            #[test]
+            fn non_negative_cents_produce_non_negative_amount(cents in 0i64..=i64::MAX/100) {
+                let m = Money::from_cents(cents, Currency::EUR);
+                prop_assert!(m.amount >= rust_decimal::Decimal::ZERO);
+            }
+        }
     }
 }

--- a/billing-engine/src/money.rs
+++ b/billing-engine/src/money.rs
@@ -2,7 +2,7 @@ use rust_decimal::prelude::{RoundingStrategy, ToPrimitive};
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 
-use crate::error::BillingError;
+use crate::error::AppError;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Currency {
@@ -31,7 +31,15 @@ pub struct Money {
 
 impl Money {
     /// Creates a `Money` value from a decimal amount.
-    pub fn new(amount: Decimal, currency: Currency) -> Self {
+    ///
+    /// # Note
+    /// This is `pub(crate)` intentionally. External callers must use `from_cents`
+    /// which is bounded by `i64`, ensuring `to_cents()` cannot overflow.
+    /// Using arbitrary `Decimal` values may produce `AppError::Overflow` in `to_cents()`.
+    ///
+    /// Used in tests and by `proration.rs` (not yet implemented).
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn new(amount: Decimal, currency: Currency) -> Self {
         Self { amount, currency }
     }
 
@@ -53,11 +61,11 @@ impl Money {
     /// (approximately ±92 trillion cents / ±920 billion USD). This should
     /// never occur with amounts created via `from_cents`, but can occur if
     /// `Money::new` is called with an extreme `Decimal` value.
-    pub fn to_cents(&self) -> Result<i64, BillingError> {
+    pub fn to_cents(&self) -> Result<i64, AppError> {
         (self.amount * dec!(100))
             .round_dp_with_strategy(0, RoundingStrategy::MidpointAwayFromZero)
             .to_i64()
-            .ok_or(BillingError::Overflow)
+            .ok_or(AppError::Overflow)
     }
 }
 
@@ -122,9 +130,10 @@ mod tests {
 
     #[test]
     fn to_cents_overflow_returns_error() {
-        // Amount far exceeds i64 range → must return Err, not silent 0
-        let huge = Decimal::from(i64::MAX) + Decimal::ONE;
-        let m = Money::new(huge, Currency::EUR);
+        // Actual overflow boundary: to_cents() multiplies by 100 internally,
+        // so the safe ceiling is i64::MAX/100. Test at i64::MAX/100 + 1.
+        let just_over = Decimal::from(i64::MAX / 100) + Decimal::ONE;
+        let m = Money::new(just_over, Currency::EUR);
         assert!(m.to_cents().is_err());
     }
 

--- a/billing-engine/src/plans.rs
+++ b/billing-engine/src/plans.rs
@@ -8,7 +8,16 @@ pub enum BillingInterval {
 }
 
 impl BillingInterval {
-    /// Returns the number of days in this billing period (approximate for yearly).
+    /// Returns an **approximate** number of days in this billing interval.
+    ///
+    /// # ⚠️ Do NOT use for proration calculations
+    /// These are fixed constants (30 / 365) and do not reflect the actual
+    /// calendar days in a given billing period. For proration, derive
+    /// `days_in_period` from `current_period_start` and `current_period_end`
+    /// timestamps provided by Stripe — otherwise Stripe's proration will
+    /// diverge from ours for months with 28, 29, or 31 days.
+    ///
+    /// Safe uses: UI hints, rough estimates, plan descriptions.
     pub fn days_in_period(&self) -> u32 {
         match self {
             BillingInterval::Monthly => 30,


### PR DESCRIPTION
## Feature

Rust billing-engine Grundstruktur (Feature 1.4). Bibliothek mit Kern-Typen und Fehlerbehandlung — Fundament für alle späteren Billing-Berechnungen (Proration, Invoice-Generierung).

## Enthaltene Tickets

- #20 Money type and Currency enum (TDD + proptest)
- #21 AppError enum and lib.rs public API

## Änderungen

**`billing-engine/src/money.rs`**
- `Money { amount: Decimal, currency: Currency }` — `rust_decimal::Decimal` only, kein `f64`/`f32`
- `from_cents(i64)` → exakte `Decimal::new(cents, 2)` Konstruktion
- `to_cents()` → `Result<i64, AppError>` mit `ROUND_HALF_UP` (nicht Banker's Rounding)
- `Money::new()` auf `pub(crate)` eingeschränkt — externe Aufrufer nutzen `from_cents()`
- proptest: round-trip Invariante `from_cents(x).to_cents() == x` für ±92T Cent

**`billing-engine/src/error.rs`**
- `AppError` Enum (ersetzt `BillingError`): `DivisionByZero`, `InvalidAmount`, `NegativeAmount`, `InvalidPeriod`, `CurrencyMismatch`, `Overflow`
- `NegativeAmount` eigenständige Variante (programmatisch matchbar, kein String-Parse)
- `thiserror::Error` v2, alle Varianten mit sinnvollen Fehlermeldungen

**`billing-engine/src/lib.rs`**
- Re-exportiert: `Money`, `Currency`, `AppError`

**`billing-engine/src/plans.rs`**
- Doc-Warnung auf `days_in_period()`: darf nicht für Proration verwendet werden (feste 30/365 Konstanten)

## Getestet

- [x] `cargo fmt --check` grün
- [x] `cargo clippy -- -D warnings` grün
- [x] `cargo test` 22/22 grün (unit tests + proptest)
- [x] `@billing-reviewer` für beide Tickets konsultiert — alle Findings behoben
- [x] Keine Secrets, kein `.unwrap()` außerhalb von `#[cfg(test)]`

closes #20, closes #21